### PR TITLE
Text-To-ASCII-Art added

### DIFF
--- a/Python/text-To-ASCII-art/README.md
+++ b/Python/text-To-ASCII-art/README.md
@@ -1,0 +1,68 @@
+# ASCII Art Text Converter
+
+A simple Tkinter GUI tool that converts input text into ASCII art using the pyfiglet library.
+
+## ⚙️ Requirements
+
+- Python 3.8+
+- pip (comes with Python)
+- tkinter (included in most Python installs)
+- pyfiglet — install with:
+
+```
+pip install pyfiglet
+```
+
+## 🚀 How to Run (Windows / Linux / macOS)
+
+1. Clone or download this repo
+
+```
+cd path/to/text-To-ASCII-art
+```
+
+2. (Optional) Create and activate a virtual environment
+
+- Windows:
+
+```
+python -m venv .venv
+.venv\Scripts\activate
+```
+
+- Linux / macOS:
+
+```
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+3. Install dependency
+
+```
+pip install pyfiglet
+```
+
+4. Run the app
+
+```
+python ascii.py
+```
+
+## 🧠 Usage
+
+- Enter your text in the input box.
+- Choose a font from the dropdown.
+- Click "Convert to ASCII Art" to see the result.
+
+## 💡 Notes
+
+On Linux, install Tkinter if missing:
+
+```
+sudo apt install python3-tk
+```
+
+If a font isn’t available, select another from the dropdown.
+
+Made by [Swayam](https://github.com/Swayam42)

--- a/Python/text-To-ASCII-art/ascii.py
+++ b/Python/text-To-ASCII-art/ascii.py
@@ -1,0 +1,56 @@
+# ASCII Art Text Converter with GUI and Font Selection
+# pip install pyfiglet
+
+import tkinter as tk
+from tkinter import messagebox, scrolledtext, ttk
+import pyfiglet
+
+def convert_text():
+    text = text_entry.get().strip()
+    font = font_combo.get().strip()
+
+    if not text:
+        messagebox.showwarning("Input Required", "Please enter some text!")
+        return
+
+    try:
+        art = pyfiglet.figlet_format(text, font=font if font else "standard")
+        output_box.delete(1.0, tk.END)
+        output_box.insert(tk.END, art)
+    except pyfiglet.FontNotFound:
+        messagebox.showerror("Error", "Selected font not found! Using default font.")
+        output_box.delete(1.0, tk.END)
+        output_box.insert(tk.END, pyfiglet.figlet_format(text))
+
+# --- GUI Setup ---
+root = tk.Tk()
+root.title("ASCII Art Converter")
+root.geometry("650x550")
+root.resizable(False, False)
+
+title_label = tk.Label(root, text="🎨 ASCII Art Text Converter", font=("Helvetica", 16, "bold"))
+title_label.pack(pady=10)
+
+# Input Section
+tk.Label(root, text="Enter Text:", font=("Arial", 11)).pack()
+text_entry = tk.Entry(root, width=50, font=("Consolas", 11))
+text_entry.pack(pady=5)
+
+# Font Selection Dropdown
+tk.Label(root, text="Choose Font:", font=("Arial", 11)).pack(pady=5)
+available_fonts = sorted(["slant", "3-d", "bubble", "digital", "starwars", "banner", "block", "doom", "shadow", "standard"])
+font_combo = ttk.Combobox(root, values=available_fonts, width=47, font=("Consolas", 10))
+font_combo.set("standard")  # Default font
+font_combo.pack(pady=5)
+
+# Convert Button
+convert_btn = tk.Button(root, text="Convert to ASCII Art", command=convert_text, bg="#4CAF50", fg="white", font=("Arial", 12, "bold"))
+convert_btn.pack(pady=10)
+
+# Output Section
+tk.Label(root, text="Generated ASCII Art:", font=("Arial", 11)).pack()
+output_box = scrolledtext.ScrolledText(root, width=75, height=15, wrap=tk.WORD, font=("Courier", 10))
+output_box.pack(pady=10)
+
+# Run GUI
+root.mainloop()


### PR DESCRIPTION
Implemented a Tkinter-based GUI for the ASCII Art Text Converter allowing users to select fonts easily. 
Added a README.md file with setup and usage instructions for better accessibility.
FONT : slant
<img width="966" height="869" alt="image" src="https://github.com/user-attachments/assets/cba51d67-5094-42f3-8323-f7c213f9c092" />
FONT : block
<img width="971" height="868" alt="image" src="https://github.com/user-attachments/assets/f5995442-6f62-4fa0-a550-81fc834c2414" />
